### PR TITLE
Fix file permission issue while doing untar of cache archive

### DIFF
--- a/dev/pr/gcs-wif-pipelinerun.yaml
+++ b/dev/pr/gcs-wif-pipelinerun.yaml
@@ -28,7 +28,7 @@ spec:
       projected:
         sources:
           - serviceAccountToken:
-              audience: https://iam.googleapis.com/projects/272779626560/locations/global/workloadIdentityPools/openshift-pool/providers/opeshift-wif
+              audience: openshift
               expirationSeconds: 3600
               path: token
 

--- a/internal/provider/oci/fetch_test.go
+++ b/internal/provider/oci/fetch_test.go
@@ -81,11 +81,12 @@ func TestFetchInvalidFolder(t *testing.T) {
 	err = crane.Push(img, fmt.Sprintf("%s/test/crane:%s", u.Host, hash))
 	assert.NoError(t, err, "Failed to push image to registry")
 
-	folder := "/root"
+	folder := "/tmp/readonly-dir-for-unit-testing"
+	_ = os.MkdirAll(folder, 0o555)
+	defer os.RemoveAll(folder)
 	insecure := false
 
 	err = Fetch(context.Background(), hash, target, folder, insecure)
-
 	assert.Error(t, err, "Fetch should return an error when folder is not writable")
 	assert.Contains(t, err.Error(), "permission denied", "Error should indicate permission issues for the folder")
 }

--- a/internal/tar/file-utils.go
+++ b/internal/tar/file-utils.go
@@ -37,6 +37,9 @@ func Tarit(source, target string) error {
 				return err
 			}
 
+			if info.IsDir() {
+				header.Mode = 0o755 //  create directories with same permissions.
+			}
 			header.Name = strings.TrimPrefix(path, source)
 
 			if err := tarball.WriteHeader(header); err != nil {
@@ -70,6 +73,7 @@ func Tarit(source, target string) error {
 }
 
 func Untar(ctx context.Context, file *os.File, target string) error {
+	log.Printf("Untaring file %s to %s", file.Name(), target)
 	f, err := os.Open(file.Name())
 	if err != nil {
 		return err

--- a/openshift/dockerfiles/cache.Dockerfile
+++ b/openshift/dockerfiles/cache.Dockerfile
@@ -28,5 +28,3 @@ LABEL \
 RUN microdnf install -y shadow-utils
 RUN groupadd -r -g 65532 nonroot && useradd --no-log-init -r -u 65532 -g nonroot nonroot
 USER 65532
-
-ENTRYPOINT ["/ko-app/cache"]


### PR DESCRIPTION
* Add Dockerfile for konflux  adoption

* Add shadow-utils and entrypoint

* Add rpms

* Fix file permission issue while doing untar of cache archive.

Remove Entry Point as it is not required.

Fix Unit Test so it runs on machines where /root directory is not present.

update audience in GCS WIF Pipelinerun