### PR TITLE
.konflux/dockerfiles: update go builder image to 1.23

### DIFF
--- a/.konflux/dockerfiles/cache.Dockerfile
+++ b/.konflux/dockerfiles/cache.Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_BUILDER=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.22
+ARG GO_BUILDER=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.23
 ARG RUNTIME=registry.access.redhat.com/ubi9/ubi-minimal@sha256:dee813b83663d420eb108983a1c94c614ff5d3fcb5159a7bd0324f0edbe7fca1
 
 FROM $GO_BUILDER AS builder


### PR DESCRIPTION
Signed-off-by: Vincent Demeester <vdemeest@redhat.com>
