### PR TITLE
use -m option is dockerfile so that home directory for nonroot user is created

### DIFF
--- a/.konflux/dockerfiles/cache.Dockerfile
+++ b/.konflux/dockerfiles/cache.Dockerfile
@@ -25,6 +25,5 @@ LABEL \
       io.k8s.description="Red Hat OpenShift Pipelines Tekton Caches" \
       io.openshift.tags="pipelines,tekton,openshift,tekton-caches"
 
-RUN microdnf install -y shadow-utils && \
-    groupadd -r -g 65532 nonroot && useradd --no-log-init -r -u 65532 -g nonroot nonroot
+RUN groupadd -r -g 65532 nonroot && useradd --no-log-init -rm -u 65532 -g nonroot nonroot
 USER 65532


### PR DESCRIPTION
This is required so that kubernetes can copy the docker creds to $HOME/.docker/config.json