### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for tekton-caches-1-19-cache

### DIFF
--- a/.konflux/dockerfiles/cache.Dockerfile
+++ b/.konflux/dockerfiles/cache.Dockerfile
@@ -17,8 +17,9 @@ COPY --from=builder /tmp/cache /ko-app/cache
 
 LABEL \
       com.redhat.component="openshift-pipelines-tekton-caches" \
-      name="openshift-pipelines/pipelines-tekton-caches-rhel9" \
+      name="openshift-pipelines/pipelines-cache-rhel9" \
       version=$VERSION \
+      cpe="cpe:/a:redhat:openshift_pipelines:1.19::el9" \
       summary="Red Hat OpenShift Pipelines Tekton Caches" \
       maintainer="pipelines-extcomm@redhat.com" \
       description="Red Hat OpenShift Pipelines Tekton Caches" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
