### PR TITLE
fix: correct typos in README, CLI flags, StepAction, and autodetect

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ spec:
           - name: CACHE_PATH
             value: $(workspace.source.path)/cache
           - name: WORKING_DIR
-            value: $(worksoaces.source.path)/repo
+            value: $(workspaces.source.path)/repo
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: $(workspace.google-credentials.path)/$(params.serviceAccountName)
       - # […] something else like go build

--- a/cmd/cache/fetch.go
+++ b/cmd/cache/fetch.go
@@ -74,7 +74,7 @@ func fetchCmd() *cobra.Command {
 	cmd.Flags().String(sourceFlag, "", "Cache source reference")
 	cmd.Flags().String(folderFlag, "", "Folder where to extract the content of the cache if it exists")
 	cmd.Flags().String(workingdirFlag, ".", "Working dir from where the files patterns needs to be taken")
-	cmd.Flags().Bool(insecureFlag, false, "Wether to use insecure transport or not to upload to insecure registry")
+	cmd.Flags().Bool(insecureFlag, false, "Whether to use insecure transport or not to upload to insecure registry")
 
 	return cmd
 }

--- a/cmd/cache/upload.go
+++ b/cmd/cache/upload.go
@@ -67,7 +67,7 @@ func uploadCmd() *cobra.Command {
 	cmd.Flags().String(targetFlag, "", "Cache target reference")
 	cmd.Flags().String(folderFlag, "", "Folder where to extract the content of the cache if it exists")
 	cmd.Flags().String(workingdirFlag, ".", "Working dir from where the files patterns needs to be taken")
-	cmd.Flags().Bool(insecureFlag, false, "Wether to use insecure transport or not to upload to insecure registry")
+	cmd.Flags().Bool(insecureFlag, false, "Whether to use insecure transport or not to upload to insecure registry")
 
 	return cmd
 }

--- a/internal/autodetect/patterns.go
+++ b/internal/autodetect/patterns.go
@@ -6,14 +6,14 @@ import (
 )
 
 type (
-	Pattern       []string
-	LanguePattern struct {
+	Pattern         []string
+	LanguagePattern struct {
 		Language string
 		Patterns []Pattern
 	}
 )
 
-var languagePatterns = []LanguePattern{
+var languagePatterns = []LanguagePattern{
 	{
 		Language: "go",
 		Patterns: []Pattern{

--- a/tekton/cache-upload.yaml
+++ b/tekton/cache-upload.yaml
@@ -35,7 +35,7 @@ spec:
       default: "false"
     - name: FETCHED
       description: |
-        Wether cache was fetched or not previously
+        Whether cache was fetched or not previously
       type: string
       default: "false"
     - name: FORCE_CACHE_UPLOAD


### PR DESCRIPTION
Fixes several typos across the codebase:

- **README.md**: `worksoaces` → `workspaces` in GCS example (line 126)
- **cmd/cache/fetch.go, upload.go**: `Wether` → `Whether` in insecure flag description
- **tekton/cache-upload.yaml**: `Wether` → `Whether` in param description
- **internal/autodetect/patterns.go**: `LanguePattern` → `LanguagePattern` (exported struct name) (this can be wrong if the original intention of this was to be french)