### PR TITLE
chore: update StepAction API from v1beta1 to v1

### DIFF
--- a/tekton/cache-fetch.yaml
+++ b/tekton/cache-fetch.yaml
@@ -1,9 +1,9 @@
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: StepAction
 metadata:
   name: cache-fetch
   annotations:
-    tekton.dev/pipelines.minVersion: "0.56.0"
+    tekton.dev/pipelines.minVersion: "0.62.0"
     tekton.dev/tags: "cache"
 spec:
   params:

--- a/tekton/cache-upload.yaml
+++ b/tekton/cache-upload.yaml
@@ -1,9 +1,9 @@
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: StepAction
 metadata:
   name: cache-upload
   annotations:
-    tekton.dev/pipelines.minVersion: "0.56.0"
+    tekton.dev/pipelines.minVersion: "0.62.0"
     tekton.dev/tags: "cache"
 spec:
   params:


### PR DESCRIPTION
StepAction was promoted to `v1` in Tekton Pipelines v0.62. This updates both StepAction definitions:

- `apiVersion: tekton.dev/v1beta1` → `apiVersion: tekton.dev/v1`
- `tekton.dev/pipelines.minVersion`: `0.56.0` → `0.62.0`

The `v1beta1` StepAction API may be removed in a future Tekton release.