### PR TITLE
Sanitize BLOB_QUERY_PARAMS with allow/deny policy before openBucket

### DIFF
--- a/dev/examples/10_pipeline/60_pipeline-aws.yaml
+++ b/dev/examples/10_pipeline/60_pipeline-aws.yaml
@@ -50,7 +50,7 @@ spec:
               resolver: http
               params:
                 - name: url
-                  value: https://raw.githubusercontent.com/tektoncd/catalog/main/stepaction/git-clone/0.1/git-clone.yaml
+                  value: https://raw.githubusercontent.com/tektoncd-catalog/git-clone/refs/heads/main/stepaction/git-clone/git-clone.yaml
             params:
               - name: output-path
                 value: $(workspaces.source.path)/repo

--- a/internal/provider/blob/blob.go
+++ b/internal/provider/blob/blob.go
@@ -24,13 +24,35 @@ import (
 )
 
 const (
-	cacheFile = "cache.tar.gz"
+	cacheFile             = "cache.tar.gz"
+	EnvBlobQueryParamsKey = "BLOB_QUERY_PARAMS"
 )
 
 var (
-	queryParams string
-	openBucket  = func(ctx context.Context, urlString string) (*blob.Bucket, error) {
-		bucket, err := blob.OpenBucket(ctx, urlString+queryParams)
+	allowedParams = map[string]bool{
+		"region":           true,
+		"s3ForcePathStyle": true,
+		"use_accelerate":   true,
+		"fips":             true,
+	}
+
+	// Blocked parameters that MUST NOT be set via user or untrusted config.
+	forbiddenParams = map[string]bool{
+		"endpoint":      true,
+		"disable_https": true,
+		"domain":        true,
+	}
+	openBucket = func(ctx context.Context, urlString string) (*blob.Bucket, error) {
+		sanitizedQueryParams, err2 := sanitizeQueryParams()
+		if err2 != nil {
+			return nil, err2
+		}
+		bucketURL := urlString
+
+		if len(sanitizedQueryParams) > 0 {
+			bucketURL += "?" + sanitizedQueryParams.Encode()
+		}
+		bucket, err := blob.OpenBucket(ctx, bucketURL)
 		return bucket, err
 	}
 	clean = func(bucket *blob.Bucket) {
@@ -41,9 +63,28 @@ var (
 	}
 )
 
-//nolint:gochecknoinits
-func init() {
-	queryParams = os.Getenv("BLOB_QUERY_PARAMS")
+func sanitizeQueryParams() (url.Values, error) {
+	// Parse the query parameters safely
+	queryParams := os.Getenv(EnvBlobQueryParamsKey)
+	values, err := url.ParseQuery(queryParams)
+	if err != nil {
+		return nil, fmt.Errorf("invalid query parameters: %w", err)
+	}
+	sanitizedValues := url.Values{}
+	for key, val := range values {
+		lowerKey := strings.ToLower(key)
+
+		// Explicitly reject forbidden parameters
+		if forbiddenParams[lowerKey] {
+			return nil, fmt.Errorf("security policy violation: parameter %q is forbidden", key)
+		}
+
+		// Only retain parameters that are explicitly allowed
+		if allowedParams[key] || allowedParams[lowerKey] {
+			sanitizedValues[key] = val
+		}
+	}
+	return sanitizedValues, nil
 }
 
 // sanitizeLog strips newline/carriage-return characters from s to prevent log injection.

--- a/internal/provider/blob/blob.go
+++ b/internal/provider/blob/blob.go
@@ -32,7 +32,7 @@ var (
 	allowedParams = map[string]bool{
 		"region":           true,
 		"s3ForcePathStyle": true,
-		"use_accelerate":   true,
+		"accelerate":       true,
 		"fips":             true,
 	}
 

--- a/internal/provider/blob/blob_test.go
+++ b/internal/provider/blob/blob_test.go
@@ -144,6 +144,7 @@ func TestFetchAndUpload_InvalidDigest(t *testing.T) {
 // When BLOB_QUERY_PARAMS is not set
 // should return empty queryParams.
 func TestSanitizeQueryParams_Blank(t *testing.T) {
+	t.Setenv(EnvBlobQueryParamsKey, "")
 	sanitizedQueryParams, err := sanitizeQueryParams()
 	assert.NoError(t, err)
 	assert.Empty(t, sanitizedQueryParams)
@@ -152,11 +153,10 @@ func TestSanitizeQueryParams_Blank(t *testing.T) {
 // When BLOB_QUERY_PARAMS is set to allowed values
 // All query params should be retained.
 func TestSanitizeQueryParams_Allowed(t *testing.T) {
-	t.Setenv("BLOB_QUERY_PARAMS", "fips")
+	t.Setenv(EnvBlobQueryParamsKey, "fips=true")
 	sanitizedQueryParams, err := sanitizeQueryParams()
 	assert.NoError(t, err)
-	assert.NotEmpty(t, sanitizedQueryParams)
-	assert.Contains(t, sanitizedQueryParams, "fips")
+	assert.Equal(t, "true", sanitizedQueryParams.Get("fips"))
 }
 
 // When BLOB_QUERY_PARAMS is set to Disallowed values

--- a/internal/provider/blob/blob_test.go
+++ b/internal/provider/blob/blob_test.go
@@ -140,3 +140,39 @@ func TestFetchAndUpload_InvalidDigest(t *testing.T) {
 	err = Fetch(ctx, *testURL, tempDir, expectedDigest)
 	assert.EqualError(t, err, fmt.Sprintf("cache integrity validation failed: expected %s, got %s", expectedDigest, digest))
 }
+
+// When BLOB_QUERY_PARAMS is not set
+// should return empty queryParams.
+func TestSanitizeQueryParams_Blank(t *testing.T) {
+	sanitizedQueryParams, err := sanitizeQueryParams()
+	assert.NoError(t, err)
+	assert.Empty(t, sanitizedQueryParams)
+}
+
+// When BLOB_QUERY_PARAMS is set to allowed values
+// All query params should be retained.
+func TestSanitizeQueryParams_Allowed(t *testing.T) {
+	t.Setenv("BLOB_QUERY_PARAMS", "fips")
+	sanitizedQueryParams, err := sanitizeQueryParams()
+	assert.NoError(t, err)
+	assert.NotEmpty(t, sanitizedQueryParams)
+	assert.Contains(t, sanitizedQueryParams, "fips")
+}
+
+// When BLOB_QUERY_PARAMS is set to Disallowed values
+// If  forbidden values are set then should return error.
+func TestSanitizeQueryParams_Forbidden(t *testing.T) {
+	t.Setenv("BLOB_QUERY_PARAMS", "endpoint")
+	sanitizedQueryParams, err := sanitizeQueryParams()
+	assert.EqualError(t, err, "security policy violation: parameter \"endpoint\" is forbidden")
+	assert.Empty(t, sanitizedQueryParams)
+}
+
+// When BLOB_QUERY_PARAMS is set to Random values
+// When random QueryParams are set then those should be filtered out.
+func TestSanitizeQueryParams_Random(t *testing.T) {
+	t.Setenv("BLOB_QUERY_PARAMS", "test")
+	sanitizedQueryParams, err := sanitizeQueryParams()
+	assert.NoError(t, err)
+	assert.Empty(t, sanitizedQueryParams)
+}


### PR DESCRIPTION
## Summary

Sanitizes the `BLOB_QUERY_PARAMS` environment variable before it is appended to the bucket URL and passed to `openBucket`. Previously the raw value was concatenated onto the URL string as-is, allowing untrusted config to inject arbitrary query parameters (e.g. `endpoint`, `disable_https`) into the storage layer.

## Changes

- Introduce `sanitizeQueryParams()` which parses `BLOB_QUERY_PARAMS` with `url.ParseQuery` and applies an allow/deny policy:
  - **Allowed** params are retained: `region`, `s3ForcePathStyle`, `use_accelerate`, `fips`.
  - **Forbidden** params (`endpoint`, `disable_https`, `domain`) cause an explicit error (`security policy violation`).
  - Any other/unknown params are silently filtered out.
- Build the bucket URL from the sanitized `url.Values` (properly encoded) instead of raw string concatenation.
- Replace the package `init()` that read the env var at import time with on-demand parsing inside `openBucket`.
- Add `EnvBlobQueryParamsKey` constant for the `BLOB_QUERY_PARAMS` key.
- Update the AWS pipeline example to the new `git-clone` StepAction catalog URL.

## Testing

- `TestSanitizeQueryParams_Blank` — unset env yields empty params.
- `TestSanitizeQueryParams_Allowed` — allowed params (`fips`) are retained.
- `TestSanitizeQueryParams_Forbidden` — forbidden params (`endpoint`) return an error.
- `TestSanitizeQueryParams_Random` — unknown params are filtered out.
- Ran `make unit-tests`.